### PR TITLE
fix xml documentation for OKXTradeRestApiClient.cs

### DIFF
--- a/OKX.Api/Clients/RestApi/OKXTradeRestApiClient.cs
+++ b/OKX.Api/Clients/RestApi/OKXTradeRestApiClient.cs
@@ -301,8 +301,8 @@ public class OKXTradeRestApiClient : OKXBaseRestApiClient
     /// <param name="underlying">Underlying</param>
     /// <param name="orderType">Order Type</param>
     /// <param name="state">State</param>
-    /// <param name="after">Pagination of data to return records earlier than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
-    /// <param name="before">Pagination of data to return records newer than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
+    /// <param name="after">Pagination of data to return records later than the requested ordId</param>
+    /// <param name="before">Pagination of data to return records earlier than the requested ordId</param>
     /// <param name="limit">Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
@@ -343,8 +343,8 @@ public class OKXTradeRestApiClient : OKXBaseRestApiClient
     /// <param name="orderType">Order Type</param>
     /// <param name="state">State</param>
     /// <param name="category">Category</param>
-    /// <param name="after">Pagination of data to return records earlier than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
-    /// <param name="before">Pagination of data to return records newer than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
+    /// <param name="after">Pagination of data to return records later than the requested order id</param>
+    /// <param name="before">Pagination of data to return records earlier than the requested order id</param>
     /// <param name="begin">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="end">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="limit">Number of results per request. The maximum is 100; the default is 100.</param>
@@ -395,8 +395,8 @@ public class OKXTradeRestApiClient : OKXBaseRestApiClient
     /// <param name="orderType">Order Type</param>
     /// <param name="state">State</param>
     /// <param name="category">Category</param>
-    /// <param name="after">Pagination of data to return records earlier than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
-    /// <param name="before">Pagination of data to return records newer than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
+    /// <param name="after">Pagination of data to return records later than the requested order id</param>
+    /// <param name="before">Pagination of data to return records earlier than the requested order id</param>
     /// <param name="begin">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="end">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="limit">Number of results per request. The maximum is 100; the default is 100.</param>
@@ -445,8 +445,8 @@ public class OKXTradeRestApiClient : OKXBaseRestApiClient
     /// <param name="instFamily">Instrument family</param>
     /// <param name="underlying">Underlying</param>
     /// <param name="orderId">Order ID</param>
-    /// <param name="after">Pagination of data to return records earlier than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
-    /// <param name="before">Pagination of data to return records newer than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
+    /// <param name="after">Pagination of data to return records later than the requested <see cref="OkxTransaction.BillId"/></param>
+    /// <param name="before">Pagination of data to return records earlier than the requested <see cref="OkxTransaction.BillId"/></param>
     /// <param name="begin">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="end">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="limit">Number of results per request. The maximum is 100; the default is 100.</param>
@@ -490,13 +490,13 @@ public class OKXTradeRestApiClient : OKXBaseRestApiClient
     /// <param name="instFamily">Instrument family</param>
     /// <param name="underlying">Underlying</param>
     /// <param name="orderId">Order ID</param>
-    /// <param name="after">Pagination of data to return records earlier than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
-    /// <param name="before">Pagination of data to return records newer than the requested ts, Unix timestamp format in milliseconds, e.g. 1597026383085</param>
+    /// <param name="after">Pagination of data to return records later than the requested <see cref="OkxTransaction.BillId"/></param>
+    /// <param name="before">Pagination of data to return records earlier than the requested <see cref="OkxTransaction.BillId"/></param>
     /// <param name="begin">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="end">Filter with a begin timestamp. Unix timestamp format in milliseconds, e.g. 1597026383085</param>
     /// <param name="limit">Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
-    /// <returns></returns>
+    /// <returns>RestCallResult containing enumerable OkxTransaction list</returns>
     public virtual async Task<RestCallResult<IEnumerable<OkxTransaction>>> GetTransactionArchiveAsync(
         OkxInstrumentType instrumentType,
         string instrumentId = null,


### PR DESCRIPTION
minor correction for the before / after parameters.
- corrected statements so that `after` is later and `before` is earlier
- corrected statements that `before & after` take a unix timestamp, when tey take a Bill ID / Order ID unique identifier
- added lookup referense to `OkxTransaction.BillId` in case they take a Bill ID