### PR TITLE
Make NextFundingRate nullable

### DIFF
--- a/OKX.Api/Public/Responses/OkxPublicFundingRate.cs
+++ b/OKX.Api/Public/Responses/OkxPublicFundingRate.cs
@@ -35,7 +35,7 @@ public record OkxPublicFundingRate
     /// Next Funding Rate
     /// </summary>
     [JsonProperty("nextFundingRate")]
-    public decimal NextFundingRate { get; set; }
+    public decimal? NextFundingRate { get; set; }
 
     /// <summary>
     /// Funding Time


### PR DESCRIPTION
Small MR: Fixes error which occurs when parsing a swap which has the method "current_period". In latest version, functions using this record do not parse.