### PR TITLE
Bug Fix: NullReferenceException in GetLeverageAsync

### DIFF
--- a/OKX.Api/Account/Clients/OkxAccountRestClient.cs
+++ b/OKX.Api/Account/Clients/OkxAccountRestClient.cs
@@ -444,7 +444,7 @@ public class OkxAccountRestClient(OkxRestApiClient root) : OkxBaseRestClient(roo
             { "instId", instrumentIds }
         };
         parameters.AddEnum("mgnMode", marginMode);
-        parameters.AddEnum("ccy", currencies);
+        parameters.AddOptional("ccy", currencies);
 
         return ProcessListRequestAsync<OkxAccountLeverage>(GetUri("api/v5/account/leverage-info"), HttpMethod.Get, ct, signed: true, queryParameters: parameters);
     }


### PR DESCRIPTION
Hi~
Fixed a NullReferenceException that occurred when calling GetLeverageAsync() without specifying the optional currencies parameter.

Details:
In the original implementation, the method added the currencies parameter using:
`parameters.AddEnum("ccy", currencies);
`
When currencies was null, this led to a NullReferenceException.

Replaced with:
`parameters.AddOptional("ccy", currencies);`
